### PR TITLE
fix minor bug in Sandstorm username handling

### DIFF
--- a/sandstorm-pkgdef.capnp
+++ b/sandstorm-pkgdef.capnp
@@ -22,10 +22,10 @@ const pkgdef :Spk.PackageDefinition = (
     appTitle = (defaultText = "Wekan"),
     # The name of the app as it is displayed to the user.
 
-    appVersion = 13,
+    appVersion = 14,
     # Increment this for every release.
 
-    appMarketingVersion = (defaultText = "0.11.0~2016-11-07"),
+    appMarketingVersion = (defaultText = "0.11.0~2016-11-08"),
     # Human-readable presentation of the app version.
 
     minUpgradableAppVersion = 0,

--- a/sandstorm.js
+++ b/sandstorm.js
@@ -89,7 +89,7 @@ if (isSandstorm && Meteor.isServer) {
 
               const login = Accounts.updateOrCreateUserFromExternalService(
                 'sandstorm', sandstormInfo,
-                { profile: { name: sandstormInfo.name, fullname: sandstormInfo.name } });
+                { profile: { name: sandstormInfo.name } });
 
               updateUserPermissions(login.userId, permissions);
               done();


### PR DESCRIPTION
Setting the fullname [here](https://github.com/wefork/wekan/blob/f11873e44a7772db3543b4a82e81c289a0bddcd2/sandstorm.js#L92) can cause the username to be set by [this logic](https://github.com/wefork/wekan/blob/f11873e44a7772db3543b4a82e81c289a0bddcd2/models/users.js#L13-L16) before the usual [uniqification](https://github.com/wefork/wekan/blob/f11873e44a7772db3543b4a82e81c289a0bddcd2/sandstorm.js#L257-L273) kicks in. The result is that share-by-powerbox can appear to fail, until the recipient actually visits the grain.

The solution is to adjust the call to `Accounts.updateOrCreateFromExternalService()` to better match the [call in meteor-accounts-sandstrom](https://github.com/sandstorm-io/meteor-accounts-sandstorm/blob/15629360a5e48fe313512d132740b01cb7219ed9/server.js#L177-L178) which gets invoked when the sharing does not go through the powerbox.