### PR TITLE
Fix failure to load when navigator.language is Chinese or Finnish.

### DIFF
--- a/client/lib/i18n.js
+++ b/client/lib/i18n.js
@@ -14,8 +14,14 @@ Tracker.autorun(() => {
   if (language) {
     TAPi18n.setLanguage(language);
 
-    // XXX
-    const shortLanguage = language.split('-')[0];
-    T9n.setLanguage(shortLanguage);
+    // For languages such as Finnish (Suomi) that are not supported by meteor-accounts-t9n,
+    // the following may throw an exception. On the initial run of this `autorun()` callback,
+    // such an exception could cause the entire app to fail to load. Therefore, we catch
+    // the exception and log it as an error.
+    try {
+      T9n.setLanguage(language);
+    } catch (e) {
+      console.error(e);
+    }
   }
 });

--- a/client/lib/i18n.js
+++ b/client/lib/i18n.js
@@ -6,8 +6,8 @@ Meteor.startup(() => {
   Tracker.autorun(() => {
     const currentUser = Meteor.user();
     let language;
-    if (currentUser) {
-      language = currentUser.profile && currentUser.profile.language;
+    if (currentUser && currentUser.profile && currentUser.profile.language) {
+      language = currentUser.profile.language;
     } else {
       language = navigator.language || navigator.userLanguage;
     }

--- a/client/lib/i18n.js
+++ b/client/lib/i18n.js
@@ -2,26 +2,19 @@
 // the language reactively. If the user is not connected we use the language
 // information provided by the browser, and default to english.
 
-Tracker.autorun(() => {
-  const currentUser = Meteor.user();
-  let language;
-  if (currentUser) {
-    language = currentUser.profile && currentUser.profile.language;
-  } else {
-    language = navigator.language || navigator.userLanguage;
-  }
-
-  if (language) {
-    TAPi18n.setLanguage(language);
-
-    // For languages such as Finnish (Suomi) that are not supported by meteor-accounts-t9n,
-    // the following may throw an exception. On the initial run of this `autorun()` callback,
-    // such an exception could cause the entire app to fail to load. Therefore, we catch
-    // the exception and log it as an error.
-    try {
-      T9n.setLanguage(language);
-    } catch (e) {
-      console.error(e);
+Meteor.startup(() => {
+  Tracker.autorun(() => {
+    const currentUser = Meteor.user();
+    let language;
+    if (currentUser) {
+      language = currentUser.profile && currentUser.profile.language;
+    } else {
+      language = navigator.language || navigator.userLanguage;
     }
-  }
+
+    if (language) {
+      TAPi18n.setLanguage(language);
+      T9n.setLanguage(language);
+    }
+  });
 });


### PR DESCRIPTION
Currently Wekan fails to load if the user's browser has its preferred language as Chinese or Finnish. Part of the problem is that Wekan passes the wrong string to `T9n.setLanguage()`. See https://github.com/wekan/wekan/pull/682 for someone else who discovered this. Another part of the problem is that meteor-accounts-t9n does not support all of the languages supported by Wekan. In particular, it is missing Finnish.

This PR fixes the failure to load in all cases.