### PR TITLE
UI: Fixed background on hover for labels in filter sidebar

### DIFF
--- a/client/components/sidebar/sidebar.styl
+++ b/client/components/sidebar/sidebar.styl
@@ -51,6 +51,7 @@
 
         .member, .card-label
           margin-right: 7px
+          margin-top: 5px
 
         .sidebar-list-item-description
           flex: 1


### PR DESCRIPTION
Fixed hover background for labels in filter sidebar. Now correctly centered.