### PR TITLE
Filter by empty

### DIFF
--- a/client/components/sidebar/sidebarFilters.jade
+++ b/client/components/sidebar/sidebarFilters.jade
@@ -5,6 +5,12 @@
 
 template(name="filterSidebar")
   ul.sidebar-list
+    li(class="{{#if Filter.labelIds.isSelected undefined}}active{{/if}}")
+          a.name.js-toggle-label-filter
+            span.sidebar-list-item-description
+              <span class="username">{{_ 'filter-no-label'}}</span>
+            if Filter.labelIds.isSelected undefined
+              i.fa.fa-check
     each currentBoard.labels
       li
         a.name.js-toggle-label-filter
@@ -18,6 +24,12 @@ template(name="filterSidebar")
             i.fa.fa-check
   hr
   ul.sidebar-list
+    li(class="{{#if Filter.members.isSelected undefined}}active{{/if}}")
+          a.name.js-toggle-member-filter
+            span.sidebar-list-item-description
+              <span class="username">{{_ 'filter-no-member'}}</span>
+            if Filter.members.isSelected undefined
+              i.fa.fa-check
     each currentBoard.activeMembers
       with getUser userId
         li(class="{{#if Filter.members.isSelected _id}}active{{/if}}")

--- a/client/components/sidebar/sidebarFilters.jade
+++ b/client/components/sidebar/sidebarFilters.jade
@@ -8,7 +8,7 @@ template(name="filterSidebar")
     li(class="{{#if Filter.labelIds.isSelected undefined}}active{{/if}}")
           a.name.js-toggle-label-filter
             span.sidebar-list-item-description
-              <span class="username">{{_ 'filter-no-label'}}</span>
+              {{_ 'filter-no-label'}}
             if Filter.labelIds.isSelected undefined
               i.fa.fa-check
     each currentBoard.labels
@@ -27,7 +27,7 @@ template(name="filterSidebar")
     li(class="{{#if Filter.members.isSelected undefined}}active{{/if}}")
           a.name.js-toggle-member-filter
             span.sidebar-list-item-description
-              <span class="username">{{_ 'filter-no-member'}}</span>
+              {{_ 'filter-no-member'}}
             if Filter.members.isSelected undefined
               i.fa.fa-check
     each currentBoard.activeMembers

--- a/client/lib/filter.js
+++ b/client/lib/filter.js
@@ -61,7 +61,18 @@ class SetFilter {
 
   _getMongoSelector() {
     this._dep.depend();
-    return { $in: this._selectedElements };
+    return { $in: this._selectedElements }
+  }
+
+  _getEmptySelector() {
+    this._dep.depend();
+    let includeEmpty = false
+    this._selectedElements.forEach((el) => {
+      if (el == undefined) {
+        includeEmpty = true;
+      }
+    });
+    return includeEmpty ? { $eq: [] } : null;
   }
 }
 
@@ -95,16 +106,26 @@ Filter = {
       return {};
 
     const filterSelector = {};
+    const emptySelector = {};
+    let includeEmptySelectors = false;
     this._fields.forEach((fieldName) => {
       const filter = this[fieldName];
-      if (filter._isActive())
+      if (filter._isActive()) {
         filterSelector[fieldName] = filter._getMongoSelector();
+        emptySelector[fieldName] = filter._getEmptySelector();
+        if (emptySelector[fieldName] != null) {
+          includeEmptySelectors = true;
+        }
+      }
     });
 
     const exceptionsSelector = {_id: {$in: this._exceptions}};
     this._exceptionsDep.depend();
 
-    return {$or: [filterSelector, exceptionsSelector]};
+    if (includeEmptySelectors)
+      return {$or: [filterSelector, exceptionsSelector, emptySelector]};
+    else
+      return {$or: [filterSelector, exceptionsSelector]};
   },
 
   mongoSelector(additionalSelector) {

--- a/client/lib/filter.js
+++ b/client/lib/filter.js
@@ -61,7 +61,7 @@ class SetFilter {
 
   _getMongoSelector() {
     this._dep.depend();
-    return { $in: this._selectedElements }
+    return { $in: this._selectedElements };
   }
 
   _getEmptySelector() {

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -173,6 +173,8 @@
     "filter": "Filter",
     "filter-cards": "Filter Cards",
     "filter-clear": "Clear filter",
+    "filter-no-label": "No label",
+    "filter-no-member": "No member",
     "filter-on": "Filter is on",
     "filter-on-desc": "You are filtering cards on this board. Click here to edit filter.",
     "filter-to-selection": "Filter to selection",


### PR DESCRIPTION
Added option to filter cards by 'no member' and 'no label' properties as requested in issue #551.
Also note that translations to other languages need to be done.