### PR TITLE
fix bug where old users could see broken presence indicators on new users

### DIFF
--- a/server/publications/boards.js
+++ b/server/publications/boards.js
@@ -99,20 +99,21 @@ Meteor.publishRelations('board', function(boardId) {
       this.cursor(Attachments.find({ cardId }));
     });
 
-    // Board members. This publication also includes former board members that
-    // aren't members anymore but may have some activities attached to them in
-    // the history.
-    //
-    this.cursor(Users.find({
-      _id: { $in: _.pluck(board.members, 'userId') },
-    }, { fields: {
-      'username': 1,
-      'profile.fullname': 1,
-      'profile.avatarUrl': 1,
-    }}), function(userId) {
-      // Presence indicators
-      this.cursor(presences.find({ userId }));
-    });
+    if (board.members) {
+      // Board members. This publication also includes former board members that
+      // aren't members anymore but may have some activities attached to them in
+      // the history.
+      this.cursor(Users.find({
+        _id: { $in: _.pluck(board.members, 'userId') },
+      }, { fields: {
+        'username': 1,
+        'profile.fullname': 1,
+        'profile.avatarUrl': 1,
+      }}), function(userId) {
+        // Presence indicators
+        this.cursor(presences.find({ userId }));
+      });
+    }
   });
 
   return this.ready();


### PR DESCRIPTION
Fixes #24.

See the first example in the [publish-relations performance notes](https://github.com/Goluis/cottz-publish-relations#performance-notes).

The problem is that [this callback](https://github.com/wefork/wekan/blob/1ad41072010fb59fdbace80a0aa049634074dac1/server/publications/boards.js#L73-L116) can be called with the `board.members` variable unset, for example when a board's `modifiedAt` field is changed. This can cause the `presences` cursor to no longer work.