### PR TITLE
set isLoaded to true on both transitionend and animationend

### DIFF
--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -65,6 +65,9 @@ BlazeComponent.extendComponent({
       [`${CSSEvents.transitionend} .js-card-details`]() {
         this.isLoaded.set(true);
       },
+      [`${CSSEvents.animationend} .js-card-details`]() {
+        this.isLoaded.set(true);
+      },
     };
 
     return [{


### PR DESCRIPTION
fixes #29 

Keeping the `transitionend` event should allow IE 11 to work. (see https://github.com/wekan/wekan/commit/bda1df5ada4cc086e4e05748f8019afbb24e0117).

Adding the `animationend` event gets Chrome and Firefox to work properly.